### PR TITLE
docs: add Railway deploy button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 <div align="left">
 
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/aAhON7?utm_medium=integration&utm_source=template&utm_campaign=generic)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-Welcome-blue.svg)](https://github.com/the-momentum/open-wearables/issues)
 ![Built with: FastAPI + React + Tanstack](https://img.shields.io/badge/Built%20with-FastAPI%20%2B%20React%20%2B%20Tanstack-green.svg)


### PR DESCRIPTION
## Description

Adds a one-click Railway deploy button at the top of the README for quick and easy self-hosted deployment.

## Checklist

NA

